### PR TITLE
hotfix_backwards_compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Unreleased section to make new releases easy.
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-06-09
+
+### Fixed
+
+- Ensured backwards compatibility with 0.2.0
+
 ## [0.3.0] - 2021-06-04
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sanger_warren (0.3.0)
+    sanger_warren (0.4.0)
       bunny (~> 2.17.0)
       connection_pool (~> 2.2.0)
       multi_json (~> 1.0)

--- a/lib/warren/delay_exchange.rb
+++ b/lib/warren/delay_exchange.rb
@@ -22,7 +22,7 @@ module Warren
     def initialize(channel:, config:)
       @channel = channel
       @exchange_config = config&.fetch('exchange', nil)
-      @bindings = config&.fetch('bindings', [])
+      @bindings = config&.fetch('bindings', []) || []
     end
 
     def_delegators :channel, :nack, :ack

--- a/lib/warren/version.rb
+++ b/lib/warren/version.rb
@@ -2,5 +2,5 @@
 
 module Warren
   # Gem version number. Bump prior to release of new version
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/warren/delay_exchange_spec.rb
+++ b/spec/warren/delay_exchange_spec.rb
@@ -7,10 +7,11 @@ require 'helpers/configuration_helpers'
 
 RSpec.describe Warren::DelayExchange do
   subject(:delay_exchange) do
-    described_class.new(
-      channel: channel,
-      config: Configuration.delay_exchange_configuration(exchange_name: 'exchange_name', queue_name: 'queue_name')
-    )
+    described_class.new(channel: channel, config: config)
+  end
+
+  let(:config) do
+    Configuration.delay_exchange_configuration(exchange_name: 'exchange_name', queue_name: 'queue_name')
   end
 
   let(:queue) { instance_spy(Bunny::Queue) }
@@ -41,6 +42,16 @@ RSpec.describe Warren::DelayExchange do
 
     it 'registers bindings' do
       expect(queue).to have_received(:bind).with(exchange, {})
+    end
+
+    context 'when not configured' do
+      let(:config) { nil }
+
+      it 'does nothing', aggregate_failures: true do
+        expect(channel).not_to have_received(:queue)
+        expect(channel).not_to have_received(:exchange)
+        expect(queue).not_to have_received(:bind)
+      end
     end
   end
 


### PR DESCRIPTION
0.3.0 is unintentionally incompatible with 0.2.0, while this is compatible with a pre v1 sem-ver change, it is largely unecessary and unintentional.
