### PR TITLE
Y26-066 - [PR] [BUG] Handle top-level exceptions in unified_warehouse / warren

### DIFF
--- a/lib/warren/client.rb
+++ b/lib/warren/client.rb
@@ -103,9 +103,26 @@ module Warren
         stopped!
       else
         # Prompt any sleeping workers to check if they need to recover
-        foxes.each(&:attempt_recovery)
+        foxes.each do |fox|
+          pause_running_fox_without_consumer(fox)
+          fox.attempt_recovery
+        end
         sleep(SECONDS_TO_SLEEP)
       end
+    end
+
+    # Forces a running fox into the normal pause/recovery flow when it has no
+    # active consumer object.
+    #
+    # This handles cases where a fox is marked running but has no active consumer.
+    #
+    # @param fox [Warren::Fox] The fox to inspect
+    # @return [void]
+    def pause_running_fox_without_consumer(fox)
+      return unless fox.running? && !fox.consumer_present?
+
+      fox.warn { 'Consumer missing while running; pausing to trigger recovery' }
+      fox.pause!
     end
   end
 end

--- a/lib/warren/delay_exchange.rb
+++ b/lib/warren/delay_exchange.rb
@@ -19,8 +19,13 @@ module Warren
     # @param channel [Warren::Handler::Broadcast::Channel] A channel on which to register queues
     # @param config [Hash] queue configuration hash
     #
-    def initialize(channel:, config:)
+    def initialize(channel:, config:, channel_factory: nil)
       @channel = channel
+      # Use a factory so DelayExchange can recover from channel closure.
+      # In Fox recovery, reopen! is called with subscription.channel so
+      # Subscription and DelayExchange stay on the same channel.
+      # If no channel is passed, reopen! creates one via channel_factory.
+      @channel_factory = channel_factory
       @exchange_config = config&.fetch('exchange', nil)
       @bindings = config&.fetch('bindings', []) || []
     end
@@ -31,6 +36,20 @@ module Warren
     # keys: additional routing_keys to bind
     def activate!
       establish_bindings!
+    end
+
+    # Rebinds DelayExchange to a healthy channel after broker-side closure.
+    # Resets the memoized @exchange because exchange instances are tied to
+    # the old channel and must be rebuilt on the replacement channel.
+    #
+    # @param channel [Warren::Handler::Broadcast::Channel, nil]
+    #   Optional channel to reuse instead of creating a new one.
+    def reopen!(channel: nil)
+      raise StandardError, 'No channel factory configured' unless @channel_factory || channel
+
+      @channel = channel || @channel_factory.call
+      @exchange = nil
+      self
     end
 
     #

--- a/lib/warren/den.rb
+++ b/lib/warren/den.rb
@@ -56,13 +56,13 @@ module Warren
     #
     # @return [Warren::Fox]
     def spawn_fox
-      # We don't use with_channel as our consumer persists outside the block,
-      # and while we *can* share channels between consumers it results in them
-      # sharing the same worker pool. This process lets us control workers on
-      # a per-queue basis. Currently that just means one worker per consumer.
-      channel = Warren.handler.new_channel(worker_count: worker_count)
-      subscription = Warren::Subscription.new(channel: channel, config: queue_config)
-      delay = Warren::DelayExchange.new(channel: channel, config: delay_config)
+      # A fox is long-lived, so it needs its own channel instance.
+      # Use `channel_factory` so recovery can create a fresh channel if
+      # RabbitMQ closes the current one.
+      channel_factory = -> { Warren.handler.new_channel(worker_count: worker_count) }
+      channel = channel_factory.call
+      subscription = Warren::Subscription.new(channel: channel, config: queue_config, channel_factory: channel_factory)
+      delay = Warren::DelayExchange.new(channel: channel, config: delay_config, channel_factory: channel_factory)
       Warren::Fox.new(name: @app_name,
                       subscription: subscription,
                       adaptor: @adaptor,

--- a/lib/warren/exceptions.rb
+++ b/lib/warren/exceptions.rb
@@ -3,13 +3,19 @@
 module Warren
   # Exceptions used by the warren gem
   module Exceptions
+    # Top level error class for Warren exceptions.
+    class Error < StandardError; end
+
     # raise {Warren::Exceptions::TemporaryIssue} in a {Warren::Subscriber} to
     # nack the message, requeuing it, and sending the consumers into sleep
     # mode until the issue resolves itself.
-    TemporaryIssue = Class.new(StandardError)
+    class TemporaryIssue < Error; end
 
-    # {Warren::Exceptions::Exceptions::MultipleAcknowledgements} is raised if a message
+    # {Warren::Exceptions::MultipleAcknowledgements} is raised if a message
     # is acknowledged, or rejected (nacked) multiple times.
-    MultipleAcknowledgements = Class.new(StandardError)
+    class MultipleAcknowledgements < Error; end
+
+    # Raised when the Bunny session cannot be started.
+    class SessionStartError < Error; end
   end
 end

--- a/lib/warren/fox.rb
+++ b/lib/warren/fox.rb
@@ -113,6 +113,16 @@ module Warren
       end
     end
 
+    # Returns whether a Bunny consumer is currently registered for this fox.
+    #
+    # Used by the client control loop to detect in-process cases where the fox
+    # is marked running but has no active consumer.
+    #
+    # @return [Boolean]
+    def consumer_present?
+      !@consumer.nil?
+    end
+
     private
 
     # Our consumer operates in another thread. It is non blocking.

--- a/lib/warren/fox.rb
+++ b/lib/warren/fox.rb
@@ -2,6 +2,7 @@
 
 require 'forwardable'
 require 'bunny'
+require 'digest'
 require 'warren'
 require 'warren/helpers/state_machine'
 require 'warren/subscriber/base'
@@ -11,6 +12,7 @@ require 'warren/framework_adaptor/rails_adaptor'
 module Warren
   # A fox is a rabbitMQ consumer. It handles subscription to the queue
   # and passing message on to the registered Subscriber
+  # rubocop:disable Metrics/ClassLength
   class Fox
     # A little cute fox emoji to easily flag output from the consumers
     FOX = '🦊'
@@ -41,6 +43,9 @@ module Warren
       @adaptor = adaptor
       @subscribed_class = subscribed_class
       @state = :initialized
+      # Remember messages that could not be dead-lettered because RabbitMQ had
+      # already closed the channel, so they can be dead-lettered if redelivered.
+      @pending_dead_letter_messages = Set.new
     end
 
     states :stopping, :stopped, :paused, :starting, :started, :running
@@ -91,22 +96,20 @@ module Warren
       paused!
     end
 
-    # If the fox is paused, and a recovery attempt is scheduled, will prompt
-    # the framework adaptor to attempt to recover. (Such as reconnecting to the
-    # database). If this operation is successful will resubscribe to the queue,
-    # otherwise a further recovery attempt will be scheduled. Successive recovery
-    # attempts will be gradually further apart, up to the MAX_RECONNECT_DELAY
-    # of 5 minutes.
+    # If the fox is paused and a recovery attempt is due, asks the framework
+    # adaptor whether recovery has succeeded (such as reconnecting to the
+    # database). If so, it reopens its subscriptions and resubscribes;
+    # otherwise a further recovery attempt will be scheduled. Successive
+    # recovery attempts will be gradually further apart, up to the
+    # MAX_RECONNECT_DELAY of 5 minutes.
     def attempt_recovery
       return unless paused? && recovery_due?
 
       warn { "Attempting recovery: #{@recovery_attempts}" }
       if recovered?
-        running!
-        subscribe!
+        recover_subscriptions!
       else
-        @recovery_attempts += 1
-        @recover_at = Time.now + delay_for_attempt
+        schedule_recovery_attempt
       end
     end
 
@@ -125,6 +128,9 @@ module Warren
     def unsubscribe!
       info { 'Unsubscribing' }
       @consumer&.cancel
+    rescue Bunny::Exception, Timeout::Error => e
+      warn { "Unsubscribe skipped (channel likely closed): #{e.class}: #{e.message}" }
+    ensure
       @consumer = nil
       info { 'Unsubscribed' }
     end
@@ -141,17 +147,188 @@ module Warren
       @adaptor.recovered?
     end
 
+    # Processes one delivered message.
+    #
+    # Flow:
+    # 1. Build a subscriber message wrapper.
+    # 2. If payload is marked pending dead-letter, force dead-letter.
+    # 3. Otherwise run subscriber processing + ack.
+    # 4. On {Warren::Exceptions::TemporaryIssue}, pause and requeue.
+    # 5. On any other error, log and dead-letter.
+    #
+    # @param delivery_info [Bunny::DeliveryInfo] Delivery metadata from Bunny
+    # @param properties [Bunny::MessageProperties] Message properties and headers
+    # @param payload [String] Raw message payload
+    # @return [void]
     def process(delivery_info, properties, payload)
+      message = @subscribed_class.new(self, delivery_info, properties, payload)
+
       log_message(payload) do
-        message = @subscribed_class.new(self, delivery_info, properties, payload)
-        @adaptor.handle { message._process_ }
-      rescue Warren::Exceptions::TemporaryIssue => e
-        warn { "Temporary Issue: #{e.message}" }
-        pause!
-        message.requeue(e)
-      rescue StandardError => e
-        message.dead_letter(e)
+        handle_message(message, payload)
       end
+    rescue Warren::Exceptions::TemporaryIssue => e
+      handle_temporary_issue(message, e)
+    rescue StandardError => e
+      # If RabbitMQ closes the channel before ack succeeds, that error is
+      # treated as a message handling failure as well.
+      handle_message_failure(message, e)
+    end
+
+    # Routes a message through pending-dead-letter handling or normal
+    # processing, depending on whether it was previously marked as pending.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper
+    # @param payload [String] The raw message payload
+    # @return [void]
+    def handle_message(message, payload)
+      return force_pending_dead_letter(message) if pending_dead_letter?(payload)
+
+      process_message(message)
+    end
+
+    # Handles temporary processing failures by pausing and requesting requeue.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper
+    # @param exception [StandardError] The temporary failure
+    # @return [void]
+    def handle_temporary_issue(message, exception)
+      warn { "Temporary Issue: #{exception.message}" }
+      pause!
+      safe_requeue(message, exception)
+    end
+
+    # Handles non-temporary failures by logging and requesting dead-letter.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper
+    # @param exception [StandardError] The failure that occurred
+    # @return [void]
+    def handle_message_failure(message, exception)
+      error { "Message handling failed: #{exception.class}: #{exception.message}" }
+      debug { exception.backtrace.join("\n") } if exception.backtrace
+      safe_dead_letter(message, exception)
+    end
+
+    # Returns whether the payload is marked as pending dead-letter.
+    #
+    # @param payload [String] The raw message payload
+    # @return [Boolean]
+    def pending_dead_letter?(payload)
+      @pending_dead_letter_messages.include?(compute_message_identifier(payload))
+    end
+
+    # Forces dead-letter for a message previously marked as pending.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper
+    # @return [void]
+    def force_pending_dead_letter(message)
+      warn { 'Re-processing pending dead-letter message after channel re-established; forcing dead-letter' }
+      safe_dead_letter(message, StandardError.new('Forced dead-letter after prior channel-closed nack failure'))
+    end
+
+    # Runs subscriber processing and final ack via the framework adaptor.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper
+    # @return [void]
+    def process_message(message)
+      @adaptor.handle { message._process_ }
+    end
+
+    # Requeues a message after a temporary failure.
+    #
+    # If RabbitMQ has already closed the channel, Bunny can raise while
+    # requeueing. In that case we log the failure and let broker redelivery
+    # happen after recovery instead of crashing the consumer.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper to requeue
+    # @param exception [StandardError] The exception that triggered requeueing
+    # @return [void]
+    def safe_requeue(message, exception)
+      message.requeue(exception)
+    rescue Bunny::Exception, Timeout::Error => e
+      warn { "Requeue failed (channel likely closed): #{e.class}: #{e.message}" }
+    end
+
+    # Dead-letters a message after a permanent failure.
+    #
+    # If RabbitMQ has already closed the channel, Bunny can raise while
+    # dead-lettering. In that case we remember the message so it can be
+    # forced to dead-letter if the broker redelivers it after recovery.
+    #
+    # @param message [Warren::Subscriber::Base] The message wrapper to dead-letter
+    # @param exception [StandardError] The exception that triggered dead-lettering
+    # @return [void]
+    def safe_dead_letter(message, exception)
+      message_identifier = compute_message_identifier(message.payload)
+      message.dead_letter(exception)
+      # Dead-letter succeeded, remove from pending if present
+      @pending_dead_letter_messages.delete(message_identifier)
+    rescue Bunny::Exception, Timeout::Error => e
+      message_identifier = compute_message_identifier(message.payload)
+      warn { "Dead-letter failed (channel likely closed): #{e.class}: #{e.message}" }
+      @pending_dead_letter_messages.add(message_identifier)
+      pause!
+    end
+
+    # Computes a stable identifier for a message payload.
+    #
+    # Used to track messages whose dead-letter operation failed because the
+    # channel had already closed, so they can be recognized if redelivered.
+    #
+    # @param payload [String] The raw message payload
+    # @return [String] SHA256 digest for the payload
+    def compute_message_identifier(payload)
+      Digest::SHA256.hexdigest(payload)
+    end
+
+    # Rebuilds subscription state after a successful recovery check.
+    #
+    # Reopens the subscription and delay exchange on healthy channels,
+    # re-establishes their bindings, and resubscribes the consumer. If any
+    # step fails, schedules another recovery attempt.
+    #
+    # @return [void]
+    def recover_subscriptions!
+      warn { 'Attempting subscription recovery' }
+      restore_subscriptions!
+      info { 'Consumer recovered and resubscribed' }
+    rescue StandardError => e
+      handle_recovery_failure(e)
+    end
+
+    # Performs the recovery steps required to restore consumption.
+    #
+    # Reopens channel-bound objects, reactivates their bindings, transitions
+    # back to running state, and subscribes a new consumer.
+    #
+    # @return [void]
+    def restore_subscriptions!
+      subscription.reopen!
+      delayed.reopen!(channel: subscription.channel)
+      subscription.activate!
+      delayed.activate!
+      running!
+      subscribe!
+    end
+
+    # Logs a recovery failure and schedules the next retry attempt.
+    #
+    # @param exception [StandardError] The recovery failure
+    # @return [void]
+    def handle_recovery_failure(exception)
+      warn { "Recovery failed: #{exception.class}: #{exception.message}" }
+      debug { exception.backtrace.join("\n") } if exception.backtrace
+      schedule_recovery_attempt
+    end
+
+    # Schedules the next recovery attempt using exponential backoff.
+    #
+    # Increments the attempt counter and sets the next recovery time based on
+    # {#delay_for_attempt}, capped by {MAX_RECONNECT_DELAY}.
+    #
+    # @return [void]
+    def schedule_recovery_attempt
+      @recovery_attempts += 1
+      @recover_at = Time.now + delay_for_attempt
     end
 
     def log_message(payload)
@@ -162,4 +339,5 @@ module Warren
       debug { 'Finished message process' }
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/warren/framework_adaptor/rails_adaptor.rb
+++ b/lib/warren/framework_adaptor/rails_adaptor.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_record'
+
 module Warren
   # Namespace for framework adaptors.
   #
@@ -35,31 +37,27 @@ module Warren
     # The RailsAdaptor provides error handling and application
     # loading for Rails applications
     class RailsAdaptor
-      # Matches errors associated with database connection loss.
-      # To understand exactly how this works, we need to go under the hood of
-      # `rescue`.
-      # When an exception is raised in Ruby, the interpreter begins unwinding
-      # the stack, looking for `rescue` statements. For each one it
-      # finds it performs the check `ExceptionClass === raised_exception`,
-      # and if this returns true, it enters the rescue block, otherwise it
-      # continues unwinding the stack.
-      # Under normal circumstances Class#=== returns true for instances of that
-      # class. Here we override that behaviour and explicitly check for a
-      # database connection instead. This ensures that regardless of what
-      # exception gets thrown if we loose access to the database, we correctly
-      # handle the message
+      # Matches exceptions that represent a lost or unavailable database
+      # connection, so they can be treated as temporary issues (pause + requeue)
+      # rather than permanent message failures (dead-letter).
+      #
+      # We override `===` so this can be used directly in a `rescue` clause.
+      # When an exception is raised, Ruby evaluates `ConnectionMissing === e`;
+      # returning true here causes the rescue block to be entered.
+      #
+      # ActiveRecord wraps all adapter-level connection errors in its own
+      # exception hierarchy, so checking these classes is both reliable and
+      # adapter-agnostic. Add to CONNECTION_ERRORS if new connectivity
+      # exception types need to be treated as temporary issues.
       class ConnectionMissing
-        def self.===(_)
-          # We used to inspect the exception, and try and check it against a list
-          # of errors that might indicate connectivity issues. But this list
-          # just grew and grew over time. So instead we just explicitly check
-          # the outcome
-          !ActiveRecord::Base.connection.active?
-        rescue StandardError => _e
-          # Unfortunately ActiveRecord::Base.connection.active? can throw an
-          # exception if it is unable to connect, and furthermore the class
-          # depends on the adapter used.
-          true
+        CONNECTION_ERRORS = [
+          ActiveRecord::ConnectionNotEstablished,
+          ActiveRecord::ConnectionFailed,
+          ActiveRecord::AdapterTimeout
+        ].freeze
+
+        def self.===(exception)
+          CONNECTION_ERRORS.any? { |klass| exception.is_a?(klass) }
         end
       end
 

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -77,7 +77,8 @@ module Warren
       # @param [Integer] pool_size The connection pool size
       # @param [String,nil] routing_key_prefix The prefix to pass before the routing key.
       #                                        Can be used to ensure environments remain distinct.
-      def initialize(exchange:, routing_key_prefix:, server: {}, pool_size: 14)
+      # @param [Hash] _kwargs Any additional keyword arguments
+      def initialize(exchange:, routing_key_prefix:, server: {}, pool_size: 14, **_kwargs)
         super()
         @server = server
         @exchange_name = exchange

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -13,8 +13,8 @@ module Warren
     # threadsafe RabbitMQ channels for broadcasting messages
     #
     class Broadcast < Warren::Handler::Base
-      MAX_START_SESSION_DELAY = 5 * 60 # max seconds for exponential backoff
-      MAX_START_SESSION_ATTEMPTS = 30 # max count before giving up
+      MAX_START_SESSION_DELAY = 5 * 60 # default seconds for exponential backoff
+      MAX_START_SESSION_ATTEMPTS = 30 # default max count before giving up
 
       # Wraps a Bunny::Channel
       # @see https://rubydoc.info/gems/bunny/Bunny/Channel
@@ -77,13 +77,15 @@ module Warren
       # @param [Integer] pool_size The connection pool size
       # @param [String,nil] routing_key_prefix The prefix to pass before the routing key.
       #                                        Can be used to ensure environments remain distinct.
-      # @param [Hash] _kwargs Any additional keyword arguments
-      def initialize(exchange:, routing_key_prefix:, server: {}, pool_size: 14, **_kwargs)
+      # @param [Hash] kwargs Any additional keyword arguments from configuration.
+      def initialize(exchange:, routing_key_prefix:, server: {}, pool_size: 14, **kwargs)
         super()
         @server = server
         @exchange_name = exchange
         @pool_size = pool_size
         @routing_key_prefix = routing_key_prefix
+        @max_start_session_delay = kwargs[:max_start_session_delay] || MAX_START_SESSION_DELAY
+        @max_start_session_attempts = kwargs[:max_start_session_attempts] || MAX_START_SESSION_ATTEMPTS
       end
 
       #
@@ -177,12 +179,12 @@ module Warren
       # Starts the Bunny session with retry logic for connection failures.
       #
       # @note Exponential backoff: 1, 2, 4, 8, ... seconds,
-      #   capped at {MAX_START_SESSION_DELAY} and
-      #   up to {MAX_START_SESSION_ATTEMPTS} attempts before giving up.
+      #   capped at {@max_start_session_delay} and
+      #   up to {@max_start_session_attempts} attempts before giving up.
       #
       # @return [true] Returns true if the session starts successfully.
       # @raise [Warren::Exceptions::SessionStartError] if the Bunny session
-      #   cannot be started after {MAX_START_SESSION_ATTEMPTS} attempts.
+      #   cannot be started after {@max_start_session_attempts} attempts.
       # rubocop:disable Metrics/MethodLength
       def start_session
         attempts = 0
@@ -190,12 +192,12 @@ module Warren
           session.start
         rescue Bunny::Exception, Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
           attempts += 1
-          if attempts >= MAX_START_SESSION_ATTEMPTS
+          if attempts >= @max_start_session_attempts
             error_message = "Failed to start session (#{e.class}): #{e.message}, attempts: #{attempts}, giving up."
             raise Warren::Exceptions::SessionStartError, error_message
           end
 
-          wait = [2**(attempts - 1), MAX_START_SESSION_DELAY].min
+          wait = [2**(attempts - 1), @max_start_session_delay].min
           $stdout.puts(
             "Failed to start session (#{e.class}): #{e.message}, " \
             "attempts: #{attempts}, retrying in #{wait}s..."

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -167,9 +167,8 @@ module Warren
       end
 
       def connection_pool
-        @connection_pool ||= begin
-          start_session
-          ConnectionPool.new(size: @pool_size, timeout: 5) { new_channel }
+        @connection_pool ||= start_session && ConnectionPool.new(size: @pool_size, timeout: 5) do
+          new_channel
         end
       end
 

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -12,6 +12,9 @@ module Warren
     # threadsafe RabbitMQ channels for broadcasting messages
     #
     class Broadcast < Warren::Handler::Base
+      MAX_START_SESSION_DELAY = 5 * 60 # max seconds for exponential backoff
+      MAX_START_SESSION_ATTEMPTS = 30 # max count before giving up
+
       # Wraps a Bunny::Channel
       # @see https://rubydoc.info/gems/bunny/Bunny/Channel
       class Channel
@@ -138,20 +141,68 @@ module Warren
         ENV.fetch('WARREN_CONNECTION_URI', @server)
       end
 
+      # Creates or retrieves the Bunny session for RabbitMQ communication.
+      #
+      # @note using default parameters for the Bunny connection such as
+      # :automatically_recover (boolean, default: true): when false, will
+      #   disable automatic network failure recovery
+      # :network_recovery_interval (number, default: 5.0): interval between
+      #   reconnection attempts
+      # :heartbeat or :heartbeat_interval (string or integer, default: :server):
+      #   standard RabbitMQ server heartbeat. :server means "use the value
+      #   from RabbitMQ config". 0 means no heartbeats (not recommended).
+      #
+      # @note :automatically_recover option is used after the initial
+      #   connection is established. If the connection cannot be established
+      #   in the first place, it will raise an exception and not retry.
+      #   Therefore, the initial connection is retried separately in the
+      #   start_session method of this handler.
+      #
+      # @see http://rubybunny.info/articles/connecting.html
+      #
+      # @return [Bunny::Session] The Bunny session object used to manage the
+      #   connection to RabbitMQ.
       def session
         @session ||= Bunny.new(server_connection)
       end
 
       def connection_pool
-        @connection_pool ||= start_session && ConnectionPool.new(size: @pool_size, timeout: 5) do
-          new_channel
+        @connection_pool ||= begin
+          start_session
+          ConnectionPool.new(size: @pool_size, timeout: 5) { new_channel }
         end
       end
 
+      # Starts the Bunny session with retry logic for connection failures.
+      #
+      # @note Exponential backoff: 1, 2, 4, 8, ... seconds,
+      #   capped at MAX_START_SESSION_DELAY and
+      #   up to MAX_START_SESSION_ATTEMPTS attempts before giving up.
+      #
+      # @return [true] Returns true if the session starts successfully.
+      # rubocop:disable Metrics/MethodLength
       def start_session
-        session.start
+        attempts = 0
+        begin
+          session.start
+        rescue Bunny::Exception, Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
+          attempts += 1
+          if attempts >= MAX_START_SESSION_ATTEMPTS
+            raise "Failed to start session (#{e.class}): #{e.message}, "\
+            "attempts: #{attempts}, giving up."
+          end
+
+          wait = [2**(attempts - 1), MAX_START_SESSION_DELAY].min
+          $stdout.puts(
+            "Failed to start session (#{e.class}): #{e.message}, " \
+            "attempts: #{attempts}, retrying in #{wait}s..."
+          )
+          sleep wait
+          retry
+        end
         true
       end
+      # rubocop:enable Metrics/MethodLength
 
       def close_session
         reset_pool

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -200,7 +200,7 @@ module Warren
             "attempts: #{attempts}, retrying in #{wait}s..."
           )
           sleep wait
-          retry
+          retry # Go to begin block
         end
         true
       end

--- a/lib/warren/handler/broadcast.rb
+++ b/lib/warren/handler/broadcast.rb
@@ -4,6 +4,7 @@ require 'bunny'
 require 'forwardable'
 require 'connection_pool'
 require_relative 'base'
+require_relative '../exceptions'
 
 module Warren
   module Handler
@@ -175,10 +176,12 @@ module Warren
       # Starts the Bunny session with retry logic for connection failures.
       #
       # @note Exponential backoff: 1, 2, 4, 8, ... seconds,
-      #   capped at MAX_START_SESSION_DELAY and
-      #   up to MAX_START_SESSION_ATTEMPTS attempts before giving up.
+      #   capped at {MAX_START_SESSION_DELAY} and
+      #   up to {MAX_START_SESSION_ATTEMPTS} attempts before giving up.
       #
       # @return [true] Returns true if the session starts successfully.
+      # @raise [Warren::Exceptions::SessionStartError] if the Bunny session
+      #   cannot be started after {MAX_START_SESSION_ATTEMPTS} attempts.
       # rubocop:disable Metrics/MethodLength
       def start_session
         attempts = 0
@@ -187,8 +190,8 @@ module Warren
         rescue Bunny::Exception, Errno::ECONNREFUSED, Errno::ETIMEDOUT => e
           attempts += 1
           if attempts >= MAX_START_SESSION_ATTEMPTS
-            raise "Failed to start session (#{e.class}): #{e.message}, "\
-            "attempts: #{attempts}, giving up."
+            error_message = "Failed to start session (#{e.class}): #{e.message}, attempts: #{attempts}, giving up."
+            raise Warren::Exceptions::SessionStartError, error_message
           end
 
           wait = [2**(attempts - 1), MAX_START_SESSION_DELAY].min

--- a/lib/warren/subscription.rb
+++ b/lib/warren/subscription.rb
@@ -14,8 +14,12 @@ module Warren
     # @param channel [Warren::Handler::Broadcast::Channel] A channel on which to register queues
     # @param config [Hash] queue configuration hash
     #
-    def initialize(channel:, config:)
+    def initialize(channel:, config:, channel_factory: nil)
       @channel = channel
+      # Use a factory so Subscription can recover from channel closure.
+      # In Fox recovery, reopen! can reuse an explicit channel; if none is
+      # passed, reopen! creates one via channel_factory.
+      @channel_factory = channel_factory
       @queue_name = config&.fetch('name')
       @queue_options = config&.fetch('options')
       @bindings = config&.fetch('bindings')
@@ -43,6 +47,19 @@ module Warren
     # keys: additional routing_keys to bind
     def activate!
       establish_bindings!
+    end
+
+    # Recreates the channel and clears memoized queue state.
+    # Used after broker-side channel closure.
+    #
+    # @param channel [Warren::Handler::Broadcast::Channel, nil]
+    #   Optional channel to reuse instead of creating a new one.
+    def reopen!(channel: nil)
+      raise StandardError, 'No channel factory configured' unless @channel_factory || channel
+
+      @channel = channel || @channel_factory.call
+      @queue = nil
+      self
     end
 
     private

--- a/spec/warren/client_spec.rb
+++ b/spec/warren/client_spec.rb
@@ -37,7 +37,17 @@ RSpec.describe Warren::Client do
 
     context 'with a single consumer' do
       let(:client) { described_class.new(config, consumers: ['consumer_a']) }
-      let(:fox) { instance_double(Warren::Fox, run!: true, attempt_recovery: true) }
+      let(:fox) do
+        instance_double(
+          Warren::Fox,
+          run!: true,
+          attempt_recovery: true,
+          running?: false,
+          consumer_present?: true,
+          pause!: true,
+          warn: true
+        )
+      end
       let(:den) { mock_den('consumer_a', fox) }
 
       before do
@@ -60,14 +70,23 @@ RSpec.describe Warren::Client do
       it 'enters a control loop' do
         expect(fox).to have_received(:attempt_recovery)
       end
+
+      it 'pauses a running fox that has no consumer to trigger recovery' do
+        allow(fox).to receive(:running?).and_return(true)
+        allow(fox).to receive(:consumer_present?).and_return(false)
+
+        run_client(client)
+
+        expect(fox).to have_received(:pause!)
+      end
     end
 
     context 'with all consumers' do
       let(:client) { described_class.new(config, consumers: nil) }
       let(:fox) do
         [
-          instance_spy(Warren::Fox, run!: true, attempt_recovery: true),
-          instance_spy(Warren::Fox, run!: true, attempt_recovery: true)
+          instance_spy(Warren::Fox, run!: true, attempt_recovery: true, running?: false, consumer_present?: true),
+          instance_spy(Warren::Fox, run!: true, attempt_recovery: true, running?: false, consumer_present?: true)
         ]
       end
 
@@ -96,7 +115,18 @@ RSpec.describe Warren::Client do
 
     context 'with a single consumer' do
       let(:client) { described_class.new(config, consumers: ['consumer_a']) }
-      let(:fox) { instance_double(Warren::Fox, run!: true, attempt_recovery: true, stop!: true) }
+      let(:fox) do
+        instance_double(
+          Warren::Fox,
+          run!: true,
+          attempt_recovery: true,
+          stop!: true,
+          running?: false,
+          consumer_present?: true,
+          pause!: true,
+          warn: true
+        )
+      end
 
       before do
         mock_den('consumer_a', fox)

--- a/spec/warren/delay_exchange_spec.rb
+++ b/spec/warren/delay_exchange_spec.rb
@@ -70,4 +70,36 @@ RSpec.describe Warren::DelayExchange do
       )
     end
   end
+
+  describe '#reopen!' do
+    subject(:delay_exchange) do
+      described_class.new(
+        channel: channel,
+        config: config,
+        channel_factory: -> { replacement_channel }
+      )
+    end
+
+    let(:replacement_channel) do
+      instance_spy(Warren::Handler::Broadcast::Channel, queue: queue, routing_key_prefix: 'test')
+    end
+
+    before do
+      allow(channel).to receive(:exchange).and_return(instance_spy(Bunny::Exchange))
+      allow(replacement_channel).to receive(:exchange).and_return(instance_spy(Bunny::Exchange))
+      allow(channel).to receive(:publish).and_return(channel)
+      allow(replacement_channel).to receive(:publish).and_return(replacement_channel)
+
+      delay_exchange.publish('before', routing_key: 'rk')
+      delay_exchange.reopen!
+      delay_exchange.publish('after', routing_key: 'rk')
+    end
+
+    it 'replaces the channel and uses it for subsequent publish' do
+      expect(replacement_channel).to have_received(:publish).with(
+        have_attributes(payload: 'after', routing_key: 'rk', headers: {}),
+        exchange: delay_exchange.send(:exchange)
+      )
+    end
+  end
 end

--- a/spec/warren/fox_spec.rb
+++ b/spec/warren/fox_spec.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'bunny'
+require 'digest'
 require 'spec_helper'
 require 'warren/fox'
 require 'warren/subscription'
@@ -65,18 +66,36 @@ RSpec.describe Warren::Fox do
     it 'is due recovery' do
       expect(fox.send(:recovery_due?)).to be true
     end
+
+    context 'when consumer cancel fails because the channel is already closed' do
+      before do
+        allow(consumer).to receive(:cancel).and_raise(Timeout::Error.new('closed channel'))
+      end
+
+      it 'does not raise' do
+        expect { fox.pause! }.not_to raise_error
+      end
+
+      it 'is paused' do
+        expect(fox).to be_paused
+      end
+    end
   end
 
   # Process is triggered via the subscription.
   describe '#process' do
-    before do
-      delivery_info = instance_double('Bunny::DeliveryInfo', delivery_tag: 'delivery_tag')
-      allow(subscription).to receive(:subscribe).and_return(consumer).and_yield(delivery_info, 'y', 'z')
-      allow(adaptor).to receive(:handle).and_yield
-      allow(Warren::Subscriber::Base).to receive(:new).with(fox, delivery_info, 'y', 'z').and_return(message)
+    let(:message) do
+      msg = instance_spy(Warren::Subscriber::Base)
+      allow(msg).to receive(:payload).and_return('test_payload')
+      msg
     end
 
-    let(:message) { instance_spy(Warren::Subscriber::Base) }
+    before do
+      delivery_info = instance_double('Bunny::DeliveryInfo', delivery_tag: 'delivery_tag')
+      allow(subscription).to receive(:subscribe).and_return(consumer).and_yield(delivery_info, 'y', 'test_payload')
+      allow(adaptor).to receive(:handle).and_yield
+      allow(Warren::Subscriber::Base).to receive(:new).with(fox, delivery_info, 'y', 'test_payload').and_return(message)
+    end
 
     it 'processes the messages' do
       fox.run!
@@ -102,7 +121,79 @@ RSpec.describe Warren::Fox do
         fox.run!
         expect(fox).to be_paused
       end
+
+      it 'does not raise if requeue fails on a closed channel' do
+        allow(adaptor).to receive(:handle).and_raise(Warren::Exceptions::TemporaryIssue)
+        allow(message).to receive(:requeue).and_raise(Timeout::Error.new('closed channel'))
+
+        expect { fox.run! }.not_to raise_error
+      end
+
+      it 'does not raise if dead-letter fails on a closed channel' do
+        allow(message).to receive(:_process_).and_raise(NameError, 'message error')
+        allow(message).to receive(:dead_letter).and_raise(Timeout::Error.new('closed channel'))
+
+        expect { fox.run! }.not_to raise_error
+      end
+
+      it 'pauses the fox if dead-letter fails on a closed channel' do
+        allow(message).to receive(:_process_).and_raise(NameError, 'message error')
+        allow(message).to receive(:dead_letter).and_raise(Timeout::Error.new('closed channel'))
+
+        fox.run!
+        expect(fox).to be_paused
+      end
+
+      it 'tracks the message as pending dead-letter when dead-letter fails on a closed channel' do
+        allow(message).to receive(:_process_).and_raise(NameError, 'message error')
+        allow(message).to receive(:dead_letter).and_raise(Timeout::Error.new('closed channel'))
+
+        fox.run!
+        # The message should be in pending set
+        expect(fox.instance_variable_get(:@pending_dead_letter_messages)).not_to be_empty
+      end
+
+      it 'forces dead-letter when a pending message is re-delivered' do
+        message_id = Digest::SHA256.hexdigest('test_payload')
+        fox.instance_variable_get(:@pending_dead_letter_messages).add(message_id)
+
+        fox.run!
+
+        expect(message).to have_received(:dead_letter).with(instance_of(StandardError))
+      end
+
+      it 'removes pending marker after successful dead-letter on redelivery' do
+        message_id = Digest::SHA256.hexdigest('test_payload')
+        fox.instance_variable_get(:@pending_dead_letter_messages).add(message_id)
+
+        fox.run!
+
+        expect(fox.instance_variable_get(:@pending_dead_letter_messages)).not_to include(message_id)
+      end
+
+      it 'does not clear pending dead-letter messages when recovery completes' do
+        allow(adaptor).to receive(:recovered?).and_return(true)
+        allow(subscription).to receive(:subscribe).and_return(consumer)
+        recover_with_pending_dead_letter('test_payload')
+
+        expect(pending_dead_letter_messages).to include(message_id('test_payload'))
+      end
     end
+  end
+
+  def message_id(payload)
+    Digest::SHA256.hexdigest(payload)
+  end
+
+  def pending_dead_letter_messages
+    fox.instance_variable_get(:@pending_dead_letter_messages)
+  end
+
+  def recover_with_pending_dead_letter(payload)
+    fox.run!
+    fox.pause!
+    pending_dead_letter_messages.add(message_id(payload))
+    fox.attempt_recovery
   end
 
   describe 'attempt_recovery' do
@@ -130,6 +221,38 @@ RSpec.describe Warren::Fox do
         fox.attempt_recovery
         # Twice as also se the original subscription
         expect(subscription).to have_received(:subscribe).with(fox.consumer_tag).twice
+      end
+
+      it 'reopens the subscription once recovered' do
+        allow(adaptor).to receive(:recovered?).and_return(true)
+
+        fox.attempt_recovery
+
+        expect(subscription).to have_received(:reopen!)
+      end
+
+      it 'reopens delayed exchange on the subscription channel once recovered' do
+        allow(adaptor).to receive(:recovered?).and_return(true)
+
+        fox.attempt_recovery
+
+        expect(delayed).to have_received(:reopen!).with(channel: subscription.channel)
+      end
+
+      it 'reactivates the subscription once recovered' do
+        allow(adaptor).to receive(:recovered?).and_return(true)
+
+        fox.attempt_recovery
+
+        expect(subscription).to have_received(:activate!).twice
+      end
+
+      it 'reactivates the delayed exchange once recovered' do
+        allow(adaptor).to receive(:recovered?).and_return(true)
+
+        fox.attempt_recovery
+
+        expect(delayed).to have_received(:activate!).twice
       end
 
       it 'is running once recovered' do

--- a/spec/warren/framework_adaptor/rails_adaptor_spec.rb
+++ b/spec/warren/framework_adaptor/rails_adaptor_spec.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'warren/framework_adaptor/rails_adaptor'
 require 'active_record'
+require 'warren/framework_adaptor/rails_adaptor'
 
 RSpec.describe Warren::FrameworkAdaptor::RailsAdaptor do
+  let(:connection_pool) do
+    instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool).tap do |pool|
+      allow(pool).to receive(:with_connection).and_yield
+      allow(pool).to receive(:release_connection)
+    end
+  end
+
   let(:active_record_base) do
-    connection_pool = instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool)
-    allow(connection_pool).to receive(:with_connection).and_yield
     class_double(ActiveRecord::Base, connection_pool: connection_pool)
   end
 
@@ -32,38 +37,55 @@ RSpec.describe Warren::FrameworkAdaptor::RailsAdaptor do
   end
 
   describe '#handle' do
-    context 'when the database is up and working' do
-      let(:active_record_base) do
-        adapter = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, active?: true)
-        class_spy(ActiveRecord::Base, connection: adapter)
-      end
+    let(:adapter) { instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter) }
 
+    before { allow(active_record_base).to receive(:connection).and_return(adapter) }
+
+    context 'when the subscriber raises a plain StandardError (e.g. bad message logic)' do
       it 'does not capture the exception' do
-        expect { described_class.new.handle { raise 'Error' } }.to raise_error(StandardError, 'Error')
+        expect { described_class.new.handle { raise StandardError, 'bad logic' } }
+          .to raise_error(StandardError, 'bad logic')
       end
     end
 
-    context 'when the database is down' do
-      let(:active_record_base) do
-        adapter = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, active?: false)
-        class_spy(ActiveRecord::Base, connection: adapter)
-      end
-
-      it 'captures and converts the exception' do
-        expect { described_class.new.handle { raise 'Error' } }.to raise_error(Warren::Exceptions::TemporaryIssue)
+    context 'when the subscriber raises ActiveRecord::StatementInvalid (e.g. bad SQL in subscriber)' do
+      it 'does not capture the exception' do
+        expect { described_class.new.handle { raise ActiveRecord::StatementInvalid, 'bad sql' } }
+          .to raise_error(ActiveRecord::StatementInvalid)
       end
     end
 
-    context "when we can't even connect" do
-      let(:active_record_base) do
-        # adapter = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter, active?: false)
-        # class_spy(ActiveRecord::Base, connection: adapter)
-        spy = class_spy(ActiveRecord::Base)
-        allow(spy).to receive(:connection).and_raise(StandardError, 'exception depends on adapter')
-        spy
+    context 'when the subscriber raises ActiveRecord::ConnectionNotEstablished' do
+      it 'captures and converts to TemporaryIssue' do
+        expect { described_class.new.handle { raise ActiveRecord::ConnectionNotEstablished, 'gone' } }
+          .to raise_error(Warren::Exceptions::TemporaryIssue)
+      end
+    end
+
+    context 'when the subscriber raises ActiveRecord::ConnectionFailed' do
+      let(:exception) { ActiveRecord::ConnectionFailed.new('failed', sql: '', binds: [], connection_pool: nil) }
+
+      it 'captures and converts to TemporaryIssue' do
+        expect { described_class.new.handle { raise exception } }
+          .to raise_error(Warren::Exceptions::TemporaryIssue)
+      end
+    end
+
+    context 'when the subscriber raises ActiveRecord::AdapterTimeout' do
+      let(:exception) { ActiveRecord::AdapterTimeout.new('timeout', sql: '', binds: [], connection_pool: nil) }
+
+      it 'captures and converts to TemporaryIssue' do
+        expect { described_class.new.handle { raise exception } }
+          .to raise_error(Warren::Exceptions::TemporaryIssue)
+      end
+    end
+
+    context "when we can't even check out a connection" do
+      before do
+        allow(active_record_base).to receive(:connection).and_raise(StandardError, 'exception depends on adapter')
       end
 
-      it 'captures and converts the exception' do
+      it 'captures and converts to TemporaryIssue' do
         expect { described_class.new.handle { 'Nothing bad' } }.to raise_error(Warren::Exceptions::TemporaryIssue)
       end
     end

--- a/spec/warren/handler/broadcast_spec.rb
+++ b/spec/warren/handler/broadcast_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Warren::Handler::Broadcast do
   end
 
   let(:server_options) { { heartbeat: 30, frame_max: 0 } }
-  let(:bun_session) { instance_spy(Bunny::Session, create_channel: bun_channel) }
+  let(:bunny_session) { instance_spy(Bunny::Session, create_channel: bun_channel) }
   let(:bun_channel) { instance_spy(Bunny::Channel) }
   let(:bun_exchange) { instance_spy(Bunny::Exchange) }
 
   before do
-    allow(Bunny).to receive(:new).with(server_options).and_return(bun_session)
+    allow(Bunny).to receive(:new).with(server_options).and_return(bunny_session)
   end
 
   describe '#connect' do
@@ -25,7 +25,7 @@ RSpec.describe Warren::Handler::Broadcast do
 
     it 'starts the bunny session' do
       warren.connect
-      expect(bun_session).to have_received(:start)
+      expect(bunny_session).to have_received(:start)
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe Warren::Handler::Broadcast do
 
     it 'starts the bunny session' do
       warren.with_channel { |_| nil }
-      expect(bun_session).to have_received(:start)
+      expect(bunny_session).to have_received(:start)
     end
 
     it 'configures the channel' do
@@ -80,5 +80,107 @@ RSpec.describe Warren::Handler::Broadcast do
           .with('payload', routing_key: 'test.key', headers: {})
       end
     end
+  end
+
+  describe '#start_session' do
+    # Helper for setting up failures for testing retry logic.
+    # @param failures [Integer] The number of times to fail
+    # @param exception_class [Class] The exception class to raise (default: Bunny::Exception)
+    # @return [Integer] The number of times start was called
+    def stub_bunny_start_failures(failures: 2, exception_class: Bunny::Exception)
+      call_count = 0
+      allow(bunny_session).to receive(:start) do
+        call_count += 1
+        raise exception_class, 'test error' if call_count <= failures
+
+        bunny_session
+      end
+      call_count
+    end
+
+    let(:bunny_session) { instance_spy(Bunny::Session) }
+
+    before do
+      allow(Bunny).to receive(:new).and_return(bunny_session)
+      # Prevent actual sleeping and output during tests.
+      allow($stdout).to receive(:puts)
+      allow_any_instance_of(described_class).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
+    end
+
+    it 'returns true when session starts' do
+      allow(bunny_session).to receive(:start).and_return(bunny_session)
+      expect(warren.send(:start_session)).to eq true
+    end
+
+    it 'calls start once when session starts on the first try' do
+      allow(bunny_session).to receive(:start).and_return(bunny_session)
+      warren.send(:start_session)
+      expect(bunny_session).to have_received(:start).once
+    end
+
+    it 'retries and eventually succeeds' do
+      stub_bunny_start_failures(failures: 2)
+      expect(warren.send(:start_session)).to eq true
+    end
+
+    it 'retries instead of raising exception' do
+      stub_bunny_start_failures(failures: 3)
+      expect { warren.send(:start_session) }.not_to raise_error
+    end
+
+    it 'calls start multiple times when retrying' do
+      stub_bunny_start_failures(failures: 4)
+      warren.send(:start_session)
+      # Success on the 5th attempt
+      expect(bunny_session).to have_received(:start).exactly(5).times
+    end
+
+    it 'outputs retry message to $stdout' do
+      stub_bunny_start_failures(failures: 6)
+      expect { warren.send(:start_session) }.to output(/retrying in \d+s/).to_stdout
+    end
+
+    it 'raises exception after retrying the maximum number of attempts' do
+      stub_bunny_start_failures(failures: described_class::MAX_START_SESSION_ATTEMPTS)
+      expect { warren.send(:start_session) }.to raise_error(Warren::Exceptions::SessionStartError)
+    end
+
+    it 'calls start no more than the maximum number of attempts' do # rubocop:disable RSpec/MultipleExpectations
+      stub_bunny_start_failures(failures: described_class::MAX_START_SESSION_ATTEMPTS)
+      expect { warren.send(:start_session) }.to raise_error(Warren::Exceptions::SessionStartError)
+      expect(bunny_session).to have_received(:start).exactly(described_class::MAX_START_SESSION_ATTEMPTS).times
+    end
+
+    it 'raises exception with the correct error message' do
+      stub_bunny_start_failures(failures: described_class::MAX_START_SESSION_ATTEMPTS)
+      expect do
+        warren.send(:start_session)
+      end.to raise_error(Warren::Exceptions::SessionStartError,
+                         /Failed to start session \(Bunny::Exception\): test error, attempts: 30, giving up\./)
+    end
+
+    # Test that all handled exceptions trigger retries and raise exception after max attempts.
+    # Bunny::Exception is the top-level exception for Bunny errors
+    # Errno exceptions cover any exception that bubbles up from sockets.
+    # The code covers almost all possible exceptions that could be raised during
+    # connection attempts, but we can add more if needed and test here.
+    # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+    [Bunny::Exception, Errno::ECONNREFUSED, Errno::ETIMEDOUT].each do |exception_class|
+      it "retries start and raises exception for #{exception_class}" do
+        stub_bunny_start_failures(
+          failures: described_class::MAX_START_SESSION_ATTEMPTS,
+          exception_class: exception_class
+        )
+        expect do
+          warren.send(:start_session)
+        end.to raise_error(
+          Warren::Exceptions::SessionStartError,
+          /Failed to start session \(#{exception_class}\): .*test error, attempts: 30, giving up\./
+        )
+        expect(bunny_session).to have_received(:start)
+          .exactly(described_class::MAX_START_SESSION_ATTEMPTS).times
+      end
+    end
+    # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength
   end
 end

--- a/spec/warren/subscription_spec.rb
+++ b/spec/warren/subscription_spec.rb
@@ -60,4 +60,26 @@ RSpec.describe Warren::Subscription do
       expect(queue).to have_received(:bind).with(exchange, routing_key: 'test.c')
     end
   end
+
+  describe '#reopen!' do
+    subject(:subscription) do
+      described_class.new(
+        channel: channel,
+        config: Configuration.topic_exchange_queue,
+        channel_factory: -> { replacement_channel }
+      )
+    end
+
+    let(:replacement_channel) do
+      instance_spy(Warren::Handler::Broadcast::Channel, queue: queue, routing_key_prefix: 'test')
+    end
+
+    it 'replaces the channel and resets memoized queue' do
+      subscription.subscribe('first') { true }
+      subscription.reopen!
+      subscription.subscribe('second') { true }
+
+      expect(replacement_channel).to have_received(:queue).with('queue_name', queue_options)
+    end
+  end
 end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

Application level solutions for connection and channel handling:

solution 1) handle channel close after timeout
- Added channel reopen support in exchange and subscription layers.
- Wired a shared channel_factory through Den so dependencies can reopen consistently.
- Hardened Fox recovery for closed-channel failures.
- Added pending dead-letter tracking so dead-letter intent survives channel closure.
- Added client-side guard for a running fox with missing consumer to re-enter recovery flow.
- Added/updated specs to cover reopen and recovery scenarios end-to-end.

solution 2) start a channel if there is none

solution 3) retry initial connection to rabbitmq - bunny session start.
- Added a retry logic with a maximum attempts to broadcast handler that is used for connection
- Added docs to explain how errors are handled 

solution 4) Top level exception handler now distinguishes between TemporaryError (database connectivity) errors and StandardError better (revealed using thinpc tests).

See also for service level solutions in the deployment project PR.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
